### PR TITLE
Update Nile utils.py

### DIFF
--- a/generators/app/templates/Nile/tests/test_ERC20.py
+++ b/generators/app/templates/Nile/tests/test_ERC20.py
@@ -2,8 +2,7 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    assert_revert, cached_contract, contract_path, get_contract_def,
-    to_uint, assert_event_emitted, str_to_felt, Signer
+    cached_contract, get_contract_def, to_uint, str_to_felt
 )
 
 

--- a/generators/app/templates/Nile/tests/test_ERC721.py
+++ b/generators/app/templates/Nile/tests/test_ERC721.py
@@ -2,8 +2,7 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    assert_revert, cached_contract, contract_path, get_contract_def,
-    to_uint, assert_event_emitted, str_to_felt, Signer
+    cached_contract, get_contract_def, str_to_felt
 )
 
 

--- a/generators/app/templates/Nile/tests/utils.py
+++ b/generators/app/templates/Nile/tests/utils.py
@@ -2,14 +2,13 @@
 #Copied from https://github.com/OpenZeppelin/cairo-contracts/blob/main/tests/utils.py
 from pathlib import Path
 import math
-from starkware.crypto.signature.signature import private_to_stark_key, sign
 from starkware.starknet.public.abi import get_selector_from_name
 from starkware.starknet.compiler.compile import compile_starknet_files
 from starkware.starkware_utils.error_handling import StarkException
 from starkware.starknet.testing.starknet import StarknetContract
-from starkware.starknet.business_logic.transaction_execution_objects import Event
-from starkware.starknet.core.os.transaction_hash import calculate_transaction_hash_common, TransactionHashPrefix
-from starkware.starknet.definitions.general_config import StarknetChainId
+from starkware.starknet.business_logic.execution.objects import Event
+from nile.signer import Signer
+
 
 MAX_UINT256 = (2**128 - 1, 2**128 - 1)
 INVALID_UINT256 = (MAX_UINT256[0] + 1, MAX_UINT256[1])
@@ -126,7 +125,7 @@ def cached_contract(state, definition, deployed):
     return contract
 
 
-class Signer():
+class TestSigner():
     """
     Utility for sending signed transactions to an Account on Starknet.
 
@@ -137,27 +136,30 @@ class Signer():
 
     Examples
     ---------
-    Constructing a Signer object
+    Constructing a TestSigner object
 
-    >>> signer = Signer(1234)
+    >>> signer = TestSigner(1234)
 
     Sending a transaction
 
-    >>> await signer.send_transaction(account,
-                                      account.contract_address,
-                                      'set_public_key',
-                                      [other.public_key]
-                                     )
+    >>> await signer.send_transaction(
+            account, contract_address, 'contract_method', [arg_1]
+        )
 
+    Sending multiple transactions
+
+    >>> await signer.send_transaction(
+            account, [
+                (contract_address, 'contract_method', [arg_1]),
+                (contract_address, 'another_method', [arg_1, arg_2])
+            ]
+        )
+                           
     """
-
     def __init__(self, private_key):
-        self.private_key = private_key
-        self.public_key = private_to_stark_key(private_key)
-
-    def sign(self, message_hash):
-        return sign(msg_hash=message_hash, priv_key=self.private_key)
-
+        self.signer = Signer(private_key)
+        self.public_key = self.signer.public_key
+        
     async def send_transaction(self, account, to, selector_name, calldata, nonce=None, max_fee=0):
         return await self.send_transactions(account, [(to, selector_name, calldata)], nonce, max_fee)
 
@@ -166,40 +168,11 @@ class Signer():
             execution_info = await account.get_nonce().call()
             nonce, = execution_info.result
 
-        (call_array, calldata) = from_call_to_call_array(calls)
+        build_calls = []
+        for call in calls:
+            build_call = list(call)
+            build_call[0] = hex(build_call[0])
+            build_calls.append(build_call)
 
-        message_hash = get_transaction_hash(account.contract_address, call_array, calldata, nonce, max_fee)
-        sig_r, sig_s = self.sign(message_hash)
-
+        (call_array, calldata, sig_r, sig_s) = self.signer.sign_transaction(hex(account.contract_address), build_calls, nonce, max_fee)
         return await account.__execute__(call_array, calldata, nonce).invoke(signature=[sig_r, sig_s])
-
-
-def from_call_to_call_array(calls):
-    call_array = []
-    calldata = []
-    for i, call in enumerate(calls):
-        assert len(call) == 3, "Invalid call parameters"
-        entry = (call[0], get_selector_from_name(
-            call[1]), len(calldata), len(call[2]))
-        call_array.append(entry)
-        calldata.extend(call[2])
-    return (call_array, calldata)
-
-def get_transaction_hash(account, call_array, calldata, nonce, max_fee):
-    execute_calldata = [
-        len(call_array),
-        *[x for t in call_array for x in t],
-        len(calldata),
-        *calldata,
-        nonce]
-
-    return calculate_transaction_hash_common(
-        TransactionHashPrefix.INVOKE,
-        TRANSACTION_VERSION,
-        account,
-        get_selector_from_name('__execute__'),
-        execute_calldata,
-        max_fee,
-        StarknetChainId.TESTNET.value,
-        []
-    )


### PR DESCRIPTION
Running tests with Nile were failing with the error:
```
tests/utils.py:10: in <module>
    from starkware.starknet.business_logic.transaction_execution_objects import Event
E   ModuleNotFoundError: No module named 'starkware.starknet.business_logic.transaction_execution_objects'
```
This is due to changes in a recent version of `cairo-lang`.

This PR does the following:
- Updates utils.py based on most recent commit https://github.com/OpenZeppelin/cairo-contracts/blob/5a9a7f1b9b6dea3f6e47d9abc1cb9f4b5637977a/tests/utils.py
- Removes unused imports in Nile tests