### PR TITLE
Add customized ERC20 tests for Nile/Hardhat/Protostar, update Wizard API

### DIFF
--- a/generators/app/erc20-test-props.js
+++ b/generators/app/erc20-test-props.js
@@ -43,21 +43,21 @@ function getConstructorProps(props) {
       vars.push("OWNER = 42");
     }
 
+    const initialSupply = erc20.getInitialSupply(
+      props.erc20premint,
+      props.erc20decimals
+    );
     vars.push("SPENDER = 9");
     vars.push(`NAME = str_to_felt("${props.erc20name}")`);
     vars.push(`SYMBOL = str_to_felt("${props.erc20symbol}")`);
-    vars.push(
-      `INIT_SUPPLY = to_uint(${erc20.getInitialSupply(
-        props.erc20premint,
-        props.erc20decimals
-      )})`
-    );
+    vars.push(`INIT_SUPPLY = to_uint(${initialSupply})`);
     vars.push(`DECIMALS = ${props.erc20decimals}`);
 
     return {
       testingVars: formatLines(vars),
       constructorCalldata: formatArgs(calldata),
       hasOwner: needsVariable(calldata, "OWNER"),
+      erc20InitialSupply: initialSupply,
     };
   }
 
@@ -98,6 +98,7 @@ function getConstructorProps(props) {
       testingVars: formatLines(vars),
       constructorCalldata: formatArgs(calldata),
       hasOwner: needsVariable(calldata, "owner"),
+      erc20InitialSupply: initialSupply,
     };
   }
 

--- a/generators/app/erc20.js
+++ b/generators/app/erc20.js
@@ -1,7 +1,6 @@
-const {
-  printERC20,
-  erc20defaults: defaults,
-} = require("@openzeppelin/wizard-cairo");
+const { erc20 } = require("@openzeppelin/wizard-cairo");
+
+const { print, defaults } = erc20;
 
 const erc20prompts = [
   {
@@ -61,7 +60,7 @@ const erc20prompts = [
 ];
 
 function erc20print(props) {
-  return printERC20({
+  return print({
     name: props.erc20name,
     symbol: props.erc20symbol,
     decimals: props.erc20decimals,

--- a/generators/app/erc721-test-props.js
+++ b/generators/app/erc721-test-props.js
@@ -34,9 +34,9 @@ function getConstructorProps(props) {
     return {
       testingVars: needsOwnerVariable(calldata)
         ? formatLines([
-          "OWNER = 42",
-          `NAME = str_to_felt("${props.erc721name}")`,
-        ])
+            "OWNER = 42",
+            `NAME = str_to_felt("${props.erc721name}")`,
+          ])
         : `NAME = str_to_felt("${props.erc721name}")`,
       constructorCalldata: formatArgs(calldata),
     };
@@ -58,9 +58,9 @@ function getConstructorProps(props) {
     return {
       testingVars: needsOwnerVariable(calldata)
         ? formatLines([
-          "const OWNER = 42",
-          `const NAME = starknet.shortStringToBigInt("${props.erc721name}")`,
-        ])
+            "const OWNER = 42",
+            `const NAME = starknet.shortStringToBigInt("${props.erc721name}")`,
+          ])
         : `const NAME = starknet.shortStringToBigInt("${props.erc721name}")`,
       constructorCalldata: formatArgs(calldata),
     };
@@ -70,28 +70,24 @@ function getConstructorProps(props) {
     const calldata = [];
 
     if (props.erc721mintable || props.erc721pausable) {
-      calldata.push(
-        props.erc721upgradeable ? "owner: accountAddress" : "owner: OWNER"
-      );
+      calldata.push("ids.OWNER"); // Owner
     }
 
     if (props.erc721upgradeable) {
-      calldata.push("proxy_admin: accountAddress"); // Proxy admin
+      calldata.push("ids.OWNER"); // Proxy admin
     }
 
     return {
       testingVars: needsOwnerVariable(calldata)
         ? formatLines([
-          "const OWNER = 42",
-          `const NAME = '${props.erc721name}')`,
-        ])
-        : `const NAME = '${props.erc721name}')`,
+            "const OWNER = 42",
+            `const NAME = '${props.erc721name}'`,
+          ])
+        : `const NAME = '${props.erc721name}'`,
       constructorCalldata: formatArgs(calldata),
     };
   }
 }
-
-
 
 function needsOwnerVariable(calldata) {
   return calldata.some((s) => s.includes("OWNER"));

--- a/generators/app/erc721.js
+++ b/generators/app/erc721.js
@@ -1,7 +1,6 @@
-const {
-  printERC721,
-  erc721defaults: defaults,
-} = require("@openzeppelin/wizard-cairo");
+const { erc721 } = require("@openzeppelin/wizard-cairo");
+
+const { print, defaults } = erc721;
 
 const erc721prompts = [
   {
@@ -49,7 +48,7 @@ const erc721prompts = [
 ];
 
 function erc721print(props) {
-  return printERC721({
+  return print({
     name: props.erc721name,
     symbol: props.erc721symbol,
     mintable: props.erc721mintable,

--- a/generators/app/templates/Hardhat/tests/ERC20_Custom.js
+++ b/generators/app/templates/Hardhat/tests/ERC20_Custom.js
@@ -94,7 +94,7 @@ describe("Test contract : ERC20", function () {
             await account.invoke(contract, "approve", { spender: SPENDER, amount: { low: 10n, high: 0 } });
             await account.invoke(contract, "transfer", { recipient: SPENDER, amount: { low: 10n, high: 0 } });
             const { balance: b1 } = await contract.call("balanceOf", { account: owner });
-            expect(b1.low).to.equal(990n);
+            expect(b1.low).to.equal(<%= erc20InitialSupply %>n-10n);
             expect(b1.high).to.equal(0n);
             const { balance: b2 } = await contract.call("balanceOf", { account: SPENDER });
             expect(b2.low).to.equal(10n);

--- a/generators/app/templates/Hardhat/tests/ERC20_Custom.js
+++ b/generators/app/templates/Hardhat/tests/ERC20_Custom.js
@@ -88,7 +88,7 @@ describe("Test contract : ERC20", function () {
         });
         <% } %>
     });
-    <% if (hasOwner) { %>
+    <% if (hasOwner && erc20InitialSupply >= 10) { %>
     describe("Testing transfer", function () {
         it("Should make sure that when transferring the balances are correctly updated", async function () {
             await account.invoke(contract, "approve", { spender: SPENDER, amount: { low: 10n, high: 0 } });

--- a/generators/app/templates/Hardhat/tests/ERC20_Custom.js
+++ b/generators/app/templates/Hardhat/tests/ERC20_Custom.js
@@ -7,19 +7,103 @@ describe("Test contract : ERC20", function () {
 
     let contractFactory;
     let contract;
+    let owner;
     this.timeout(300_000);
 
     before(async () => {
         contractFactory = await starknet.getContractFactory("ERC20");
+        account = await starknet.deployAccount("OpenZeppelin");
+        owner = account.starknetContract.address;
         contract = await contractFactory.deploy({
             <%= constructorCalldata %>
         });
     });
 
-    describe("Deploy", function () {
-        it("Should deploy an ERC20 contract and make sure it has the correct name", async function () {
+    describe("Testing deploy ERC20", function () {
+        it("Should make sure it has the correct name", async function () {
             const { name } = await contract.call("name", {});
             expect(name).to.equal(NAME);
         });
+        it("Should make sure it has the correct symbol", async function () {
+            const { symbol } = await contract.call("symbol", {});
+            expect(symbol).to.equal(SYMBOL);
+        });
+        it("Should make sure it has the correct decimals", async function () {
+            const { decimals } = await contract.call("decimals", {});
+            expect(decimals).to.equal(DECIMALS);
+        });
+        it("Should make sure it has the correct totalSupply", async function () {
+            const { totalSupply } = await contract.call("totalSupply", {});
+            expect(totalSupply.low).to.equal(INIT_SUPPLY.low);
+            expect(totalSupply.high).to.equal(INIT_SUPPLY.high);
+        });
+        <% if (hasOwner) { %>
+        it("Should make sure the initial supply is correctly transferred to the owner", async function () {
+            const { balance } = await contract.call("balanceOf", { account: owner });
+            expect(balance.low).to.equal(INIT_SUPPLY.low);
+            expect(balance.high).to.equal(INIT_SUPPLY.high);
+        });
+        <% } %>
     });
+
+    describe("Testing approval", function () {
+        <% if (hasOwner) { %>
+        it("Should check that the default allowance is zero then increase it and make sure it is correctly increased", async function () {
+            const { remaining: r1 } = await contract.call("allowance", { owner: owner, spender: SPENDER });
+            expect(r1.low).to.equal(0n);
+            expect(r1.high).to.equal(0n);
+            await account.invoke(contract, "approve", { spender: SPENDER, amount: { low: 10n, high: 11n } });
+            const { remaining: r2 } = await contract.call("allowance", { owner: owner, spender: SPENDER });
+            expect(r2.low).to.equal(10n);
+            expect(r2.high).to.equal(11n);
+        });
+        <% } %>
+        it("Should fail when calling approve when the spender is the zero address", async function () {
+            try {
+                await account.invoke(contract, "approve", { spender: 0n, amount: { low: 10n, high: 11n } });
+                expect.fail("Should have failed when the spender is the zero address");
+            } catch (err) {
+                expect(err.message).to.contain("ERC20: cannot approve to the zero address");
+            }
+        });
+        it("Should fail when calling approve when the caller is the zero address", async function () {
+            try {
+                await contract.invoke("approve", { spender: SPENDER, amount: { low: 10n, high: 11n } });
+                expect.fail("Should have failed when the spender is the zero address");
+            } catch (err) {
+                expect(err.message).to.contain("ERC20: zero address cannot approve");
+            }
+        });
+        <% if (hasOwner) { %>
+        it("Should make sure that an event is triggered when calling approve", async function () {
+            const txHash = await account.invoke(contract, "approve", { spender: SPENDER, amount: { low: 10n, high: 11n } });
+            const receipt = await starknet.getTransactionReceipt(txHash);
+            const firstEvent = receipt.events[0]
+            expect(parseHexToBigInt(firstEvent.data[0])).to.equal(parseHexToBigInt(owner))
+            expect(parseHexToBigInt(firstEvent.data[1])).to.equal(9n)
+            expect(parseHexToBigInt(firstEvent.data[2])).to.equal(10n)
+            expect(parseHexToBigInt(firstEvent.data[3])).to.equal(11n)
+            expect(parseHexToBigInt(firstEvent.from_address)).to.equal(parseHexToBigInt(contract.address))
+            expect(firstEvent.keys[0]).to.equal("0x134692b230b9e1ffa39098904722134159652b09c5bc41d88d6698779d228ff") // "Aproval"
+        });
+        <% } %>
+    });
+    <% if (hasOwner) { %>
+    describe("Testing transfer", function () {
+        it("Should make sure that when transferring the balances are correctly updated", async function () {
+            await account.invoke(contract, "approve", { spender: SPENDER, amount: { low: 10n, high: 0 } });
+            await account.invoke(contract, "transfer", { recipient: SPENDER, amount: { low: 10n, high: 0 } });
+            const { balance: b1 } = await contract.call("balanceOf", { account: owner });
+            expect(b1.low).to.equal(990n);
+            expect(b1.high).to.equal(0n);
+            const { balance: b2 } = await contract.call("balanceOf", { account: SPENDER });
+            expect(b2.low).to.equal(10n);
+            expect(b2.high).to.equal(0n);
+        });
+    });
+    <% } %>
 });
+
+function parseHexToBigInt(hexValue) {
+    return BigInt(parseInt(hexValue, 16))
+}

--- a/generators/app/templates/Hardhat/tests/ERC20_Upgradeable.js
+++ b/generators/app/templates/Hardhat/tests/ERC20_Upgradeable.js
@@ -12,8 +12,8 @@ describe("Test contract : ERC20", function () {
 
     before(async () => {
         account = await starknet.deployAccount("OpenZeppelin");
-        const accountAddress = account.starknetContract.address;
-        console.log(`Deployed account ${accountAddress}`);
+        const owner = account.starknetContract.address;
+        console.log(`Deployed account ${owner}`);
         
         const implFactory = await starknet.getContractFactory("ERC20");
         const impl = await implFactory.deploy();

--- a/generators/app/templates/Nile/tests/test_ERC20_Custom.py
+++ b/generators/app/templates/Nile/tests/test_ERC20_Custom.py
@@ -2,7 +2,7 @@
 import pytest
 from starkware.starknet.testing.starknet import Starknet
 from utils import (
-    cached_contract, get_contract_def, to_uint, str_to_felt
+    cached_contract, get_contract_def, to_uint, str_to_felt, assert_event_emitted, assert_revert
 )
 
 # testing vars
@@ -34,8 +34,69 @@ def erc20_factory(contract_defs, erc20_init):
     erc20 = cached_contract(_state, erc20_def, erc20)    
     return erc20
 
+# actual tests
 @pytest.mark.asyncio
-async def test_initial_data(erc20_factory):
-    erc20 = erc20_factory
-    execution_info = await erc20.name().call()
+async def test_name(erc20_factory):
+    execution_info = await erc20_factory.name().call()
     assert execution_info.result.name == NAME
+
+@pytest.mark.asyncio
+async def test_symbol(erc20_factory):
+    execution_info = await erc20_factory.symbol().call()
+    assert execution_info.result.symbol == SYMBOL
+
+@pytest.mark.asyncio
+async def test_decimals(erc20_factory):
+    execution_info = await erc20_factory.decimals().call()
+    assert execution_info.result.decimals == DECIMALS
+
+@pytest.mark.asyncio
+async def test_totalSupply(erc20_factory):
+    execution_info = await erc20_factory.totalSupply().call()
+    assert execution_info.result.totalSupply == INIT_SUPPLY
+
+<% if (hasOwner) { %>
+@pytest.mark.asyncio
+async def test_initial_supply_belong_to_owner(erc20_factory):
+    execution_info = await erc20_factory.balanceOf(account=OWNER).call()
+    assert execution_info.result.balance == INIT_SUPPLY
+
+@pytest.mark.asyncio
+async def test_initial_allowance_of_owner(erc20_factory):
+    execution_info = await erc20_factory.allowance(owner=OWNER, spender=SPENDER).call()
+    assert execution_info.result.remaining == (0,0)
+
+@pytest.mark.asyncio
+async def test_approve(erc20_factory):
+    execution_info = await erc20_factory.allowance(owner=OWNER, spender=SPENDER).call()
+    assert execution_info.result.remaining == (0,0)
+    execution_info = await erc20_factory.approve(spender=SPENDER, amount=(10,11)).invoke(caller_address=OWNER)
+    assert execution_info.result.success == 1
+    execution_info = await erc20_factory.allowance(owner=OWNER, spender=SPENDER).call()
+    assert execution_info.result.remaining == (10,11)
+ <% } %>
+
+@pytest.mark.asyncio
+async def test_approve_error_zero_address_spender(erc20_factory):
+    await assert_revert(erc20_factory.approve(spender=0, amount=(10,11)).invoke(), "ERC20: zero address cannot approve")
+
+@pytest.mark.asyncio
+async def test_approve_error_zero_address_owner(erc20_factory):
+    await assert_revert(erc20_factory.approve(spender=SPENDER, amount=(10,11)).invoke(caller_address=0), "ERC20: zero address cannot approve")
+
+<% if (hasOwner) { %>
+@pytest.mark.asyncio
+async def test_approve_event(erc20_factory):
+    execution_info = await erc20_factory.approve(spender=SPENDER, amount=(10,11)).invoke(caller_address=OWNER)
+    assert_event_emitted(execution_info, erc20_factory.contract_address, "Approval", [OWNER, SPENDER, 10,11])
+
+@pytest.mark.asyncio
+async def test_transfer(erc20_factory):
+    execution_info = await erc20_factory.transfer(recipient=SPENDER, amount=(10,0)).invoke(caller_address=OWNER)
+    await assert_balanceOf(erc20_factory, OWNER, (990,0))
+    await assert_balanceOf(erc20_factory, SPENDER, (10,0))
+<% } %>
+
+async def assert_balanceOf(erc20_factory, account, balance):
+    execution_info = await erc20_factory.balanceOf(account=account).call()
+    assert execution_info.result.balance == balance

--- a/generators/app/templates/Nile/tests/test_ERC20_Custom.py
+++ b/generators/app/templates/Nile/tests/test_ERC20_Custom.py
@@ -93,7 +93,7 @@ async def test_approve_event(erc20_factory):
 @pytest.mark.asyncio
 async def test_transfer(erc20_factory):
     execution_info = await erc20_factory.transfer(recipient=SPENDER, amount=(10,0)).invoke(caller_address=OWNER)
-    await assert_balanceOf(erc20_factory, OWNER, (990,0))
+    await assert_balanceOf(erc20_factory, OWNER, (<%= erc20InitialSupply %>-10,0))
     await assert_balanceOf(erc20_factory, SPENDER, (10,0))
 <% } %>
 

--- a/generators/app/templates/Nile/tests/test_ERC20_Custom.py
+++ b/generators/app/templates/Nile/tests/test_ERC20_Custom.py
@@ -90,11 +90,13 @@ async def test_approve_event(erc20_factory):
     execution_info = await erc20_factory.approve(spender=SPENDER, amount=(10,11)).invoke(caller_address=OWNER)
     assert_event_emitted(execution_info, erc20_factory.contract_address, "Approval", [OWNER, SPENDER, 10,11])
 
+<% if (erc20InitialSupply >= 10) { %>
 @pytest.mark.asyncio
 async def test_transfer(erc20_factory):
     execution_info = await erc20_factory.transfer(recipient=SPENDER, amount=(10,0)).invoke(caller_address=OWNER)
     await assert_balanceOf(erc20_factory, OWNER, (<%= erc20InitialSupply %>-10,0))
     await assert_balanceOf(erc20_factory, SPENDER, (10,0))
+<% } %>
 <% } %>
 
 async def assert_balanceOf(erc20_factory, account, balance):

--- a/generators/app/templates/Protostar/tests/test_ERC20_Custom.cairo
+++ b/generators/app/templates/Protostar/tests/test_ERC20_Custom.cairo
@@ -1,7 +1,7 @@
 %lang starknet
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.alloc import alloc
-
+from starkware.cairo.common.uint256 import Uint256
 
 # testing vars
 <%= testingVars %>
@@ -9,6 +9,20 @@ from starkware.cairo.common.alloc import alloc
 @contract_interface
 namespace StorageContract:
     func name() -> (name : felt):
+    end
+    func symbol() -> (symbol : felt):
+    end
+    func decimals() -> (decimals : felt):
+    end
+    func totalSupply() -> (totalSupply : Uint256):
+    end
+    func balanceOf(account : felt) -> (balance : Uint256):
+    end
+    func allowance(owner : felt, spender : felt) -> (remaining : Uint256):
+    end
+    func transfer(recipient : felt, amount : Uint256) -> (success : felt):
+    end
+    func approve(spender : felt, amount : Uint256) -> (success : felt):
     end
 end
 
@@ -22,9 +36,131 @@ func get_deployed_contract_address{
 end
 
 @external
-func test_initial_data{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+func test_name{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
     let (contract_address) = get_deployed_contract_address()
     let (name) = StorageContract.name(contract_address)
     assert name = NAME
     return ()
 end
+
+@external
+func test_symbol{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    let (contract_address) = get_deployed_contract_address()
+    let (symbol) = StorageContract.symbol(contract_address)
+    assert symbol = SYMBOL
+    return ()
+end
+
+@external
+func test_decimals{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    let (contract_address) = get_deployed_contract_address()
+    let (decimals) = StorageContract.decimals(contract_address)
+    assert decimals = DECIMALS
+    return ()
+end
+
+@external
+func test_totalSupply{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    let (contract_address) = get_deployed_contract_address()
+    let (totalSupply) = StorageContract.totalSupply(contract_address)
+    assert totalSupply.low = INIT_SUPPLY_LOW
+    assert totalSupply.high = INIT_SUPPLY_HIGH
+    return ()
+end
+
+<% if (hasOwner) { %>
+@external
+func test_initial_supply_belong_to_owner{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    let (contract_address) = get_deployed_contract_address()
+    let (balance) = StorageContract.balanceOf(contract_address, OWNER)
+    assert balance.low = INIT_SUPPLY_LOW
+    assert balance.high = INIT_SUPPLY_HIGH
+    return ()
+end
+
+@external
+func test_initial_allowance_of_owner{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    let (contract_address) = get_deployed_contract_address()
+    let (remaining) = StorageContract.allowance(contract_address, OWNER, SPENDER)
+    assert remaining.low = 0
+    assert remaining.high = 0
+    return ()
+end
+
+@external
+func test_approve{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    alloc_locals
+    let (contract_address) = get_deployed_contract_address()
+    %{ stop_prank_callable = start_prank(caller_address=ids.OWNER, target_contract_address=ids.contract_address) %}
+    let (remaining) = StorageContract.allowance(contract_address, OWNER, SPENDER)
+    assert remaining.low = 0
+    assert remaining.high = 0
+    let amount_to_approve = Uint256(10, 11)
+    StorageContract.approve(contract_address, SPENDER, amount_to_approve)
+    let (remaining1) = StorageContract.allowance(contract_address, OWNER, SPENDER)
+    assert remaining1.low = 10
+    assert remaining1.high = 11
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@external
+func test_approve_error_zero_address_spender{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    let (contract_address) = get_deployed_contract_address()
+    %{ stop_prank_callable = start_prank(caller_address=ids.OWNER, target_contract_address=ids.contract_address) %}
+    let amount_to_approve = Uint256(10, 11)
+    %{ expect_revert(error_message="ERC20: cannot approve to the zero address") %}
+    let (remaining) = StorageContract.approve(contract_address, 0, amount_to_approve)
+    %{ stop_prank_callable() %}
+    return ()
+end
+<% } %>
+
+@external
+func test_approve_error_zero_address_owner{
+    syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*
+}():
+    let (contract_address) = get_deployed_contract_address()
+    %{ stop_prank_callable = start_prank(caller_address=0, target_contract_address=ids.contract_address) %}
+    let amount_to_approve = Uint256(10, 11)
+    %{ expect_revert(error_message="ERC20: zero address cannot approve") %}
+    let (remaining) = StorageContract.approve(contract_address, 0, amount_to_approve)
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+<% if (hasOwner) { %>
+@external
+func test_approve_event{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    let (contract_address) = get_deployed_contract_address()
+    %{ stop_prank_callable = start_prank(caller_address=ids.OWNER, target_contract_address=ids.contract_address) %}
+    let amount_to_approve = Uint256(10, 11)
+    %{ expect_events({"name": "Approval", "data": [ids.OWNER, 12, 10, 11]}) %}
+    let (remaining) = StorageContract.approve(contract_address, 12, amount_to_approve)
+    %{ stop_prank_callable() %}
+    return ()
+end
+
+@external
+func test_transfer{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
+    let (contract_address) = get_deployed_contract_address()
+    %{ stop_prank_callable = start_prank(caller_address=ids.OWNER, target_contract_address=ids.contract_address) %}
+    let amount_to_transfer = Uint256(10, 0)
+    StorageContract.approve(contract_address, SPENDER, amount_to_transfer)
+    StorageContract.transfer(contract_address, SPENDER, amount_to_transfer)
+    let (balance) = StorageContract.balanceOf(contract_address, OWNER)
+    assert balance.low = <%= erc20InitialSupplyLowBits %>-10
+    assert balance.high = <%= erc20InitialSupplyHighBits %>
+    let (balance) = StorageContract.balanceOf(contract_address, SPENDER)
+    assert balance.low = 10
+    assert balance.high = 0
+    %{ stop_prank_callable() %}
+    return ()
+end
+<% } %>

--- a/generators/app/templates/Protostar/tests/test_ERC20_Custom.cairo
+++ b/generators/app/templates/Protostar/tests/test_ERC20_Custom.cairo
@@ -147,6 +147,7 @@ func test_approve_event{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : Has
     return ()
 end
 
+<% if (erc20InitialSupplyLowBits >= 10) { %>
 @external
 func test_transfer{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuiltin*}():
     let (contract_address) = get_deployed_contract_address()
@@ -163,4 +164,5 @@ func test_transfer{syscall_ptr : felt*, range_check_ptr, pedersen_ptr : HashBuil
     %{ stop_prank_callable() %}
     return ()
 end
+<% } %>
 <% } %>

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chalk": "^2.1.0",
     "yeoman-generator": "^3.1.1",
     "yosay": "^2.0.2",
-    "@openzeppelin/wizard-cairo": "^0.1.0"
+    "@openzeppelin/wizard-cairo": "^0.2.0"
   },
   "jest": {
     "testEnvironment": "node"


### PR DESCRIPTION
Fixes https://github.com/onlydustxyz/generator-starknet/issues/30

- Adds generated tests for customized ERC20 contracts in Nile/Hardhat/Protostar, to be equivalent to the generated tests for the default ERC20 contract.  Removes some parts of the template if those parts are not applicable to the customized contract (e.g. if the customized contract has 0 premint).

- Changes OpenZeppelin Wizard API calls to new format (pending https://github.com/OpenZeppelin/contracts-wizard/pull/136)
- Makes use of new API functions from OpenZeppelin Wizard to help with testing the initial supply (pending https://github.com/OpenZeppelin/contracts-wizard/pull/138)
